### PR TITLE
fix: add better HTML compression

### DIFF
--- a/src/templates/post.html
+++ b/src/templates/post.html
@@ -19,9 +19,7 @@ $partial("templates/nav.html")$
   <div class="layout--constrained">
     <ul role="list">
       <li role="listitem">
-        <span aria-hidden="true">♥</span>
-        <a href="https://github.com/sponsors/rpearce/">Sponsor my work</a>
-        <span aria-hidden="true">♥</span>
+        <span aria-hidden="true">♥</span> <a href="https://github.com/sponsors/rpearce/">Sponsor my work</a> <span aria-hidden="true">♥</span>
       </li>
       <li role="listitem">
         <a href="./atom.xml">RSS</a>


### PR DESCRIPTION
The work I did before still left a bunch of leading/trailing whitespace on content lines, and I just wasn't satisfied with a 75% reduction.

This update leans into `unwords . words` and a few more logical scenarios to get it working better!