### PR TITLE
feat: reuse my old updatedField for better revision dates

### DIFF
--- a/ssg/src/Main.hs
+++ b/ssg/src/Main.hs
@@ -5,10 +5,14 @@
 
 -- import Debug.Trace as D
 import qualified Control.Monad as Monad
+import qualified Control.Monad.Fail as MonadFail
 import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Data.Text as T
 import qualified Data.Text.Slugger as Slugger
+import qualified Data.Time.Clock as DTC
+import qualified Data.Time.Format as DTF
+import qualified Data.Time.Locale.Compat as DTLC
 import qualified Hakyll as H
 import qualified System.FilePath as FilePath
 import qualified Text.HTML.TagSoup.Compressor as TSCompressor
@@ -29,7 +33,7 @@ myFeedTitle :: String
 myFeedTitle = "Robert Pearce's blog"
 
 myFeedDescription :: String
-myFeedDescription = "Posts on JavaScript, Node.js, Haskell, Elm, Ruby and more."
+myFeedDescription = "Posts on JavaScript, Nix, Haskell, Ruby, Bash, and more."
 
 myFeedAuthorName :: String
 myFeedAuthorName = "Robert Pearce"
@@ -164,6 +168,7 @@ compressHtml = H.withTagList TSCompressor.compress
 feedCtx :: H.Context String
 feedCtx =
   titleCtx
+    <> updatedField "updated" "%Y-%m-%dT%H:%M:%SZ"
     <> postCtx
     <> H.bodyField "description"
 
@@ -173,11 +178,35 @@ postCtx =
     <> H.constField "feedTitle" myFeedTitle
     <> H.constField "siteName" mySiteName
     <> H.dateField "date" "%Y-%m-%d"
+    <> updatedField "updated" "%Y-%m-%d @ %H:%M %Z"
     <> H.defaultContext
 
 titleCtx :: H.Context String
 titleCtx =
   H.field "title" updatedTitle
+
+updatedField :: String -> String -> H.Context String
+updatedField key format = H.field key $ \i -> do
+  let locale = DTLC.defaultTimeLocale
+  time <- getUpdatedUTC locale $ H.itemIdentifier i
+  return $ DTF.formatTime locale format time
+
+getUpdatedUTC :: (H.MonadMetadata m, MonadFail m)
+              => DTLC.TimeLocale
+              -> H.Identifier
+              -> m DTC.UTCTime
+getUpdatedUTC locale id' = do
+  metadata <- H.getMetadata id'
+  let tryField k fmt = H.lookupString k metadata >>= parseTime' fmt
+  Maybe.maybe empty' return $ Monad.msum [tryField "updated" fmt | fmt <- formats]
+  where
+    empty'     = MonadFail.fail $ "getUpdatedUTC: " ++ "could not parse time for " ++ show id'
+    parseTime' = DTF.parseTimeM True locale
+    formats    =
+      [ "%Y-%m-%d"
+      , "%Y-%m-%dT%H:%M:%SZ" -- feed-friendly
+      , "%Y-%m-%d @ %H:%M %Z" -- custom for notes
+      ]
 
 --------------------------------------------------------------------------------
 -- TITLE HELPERS

--- a/ssg/ssg.cabal
+++ b/ssg/ssg.cabal
@@ -19,6 +19,8 @@ executable hakyll-site
                    , slugger >= 0.1.0.2
                    , tagsoup >= 0.14.8
                    , text >= 1 && < 3
+                   , time >= 1.8
+                   , time-locale-compat >= 0.1
   other-modules:   Text.HTML.TagSoup.Compressor
   ghc-options:     -Wall
                    -Wcompat


### PR DESCRIPTION
Use https://robertwpearce.com/hakyll-pt-3-generating-rss-and-atom-xml-feeds.html and https://github.com/jaspervdj/hakyll/blob/8b0a398a82afdb0a03b24fd0a635b9894d8909fc/lib/Hakyll/Web/Template/Context.hs#L363C15-L393 to work with an `updated` field that comes from metadata.