### PR TITLE
Improve HTML compressor and fix feed-title XML escaping

### DIFF
--- a/ssg/src/Hakyll/Site/Feed.hs
+++ b/ssg/src/Hakyll/Site/Feed.hs
@@ -59,13 +59,19 @@ atomCtx =
 --------------------------------------------------------------------------------
 -- TITLE HELPERS
 
-replaceAmp :: String -> String
-replaceAmp =
-  H.replaceAll "&" (const "&amp;")
+-- | Escape the XML metacharacters that would otherwise produce invalid
+-- RSS/Atom feeds. The @&@ pass must run first so it does not re-escape the
+-- ampersands introduced by the other entities.
+escapeXml :: String -> String
+escapeXml =
+  H.replaceAll "\"" (const "&quot;")
+    . H.replaceAll ">" (const "&gt;")
+    . H.replaceAll "<" (const "&lt;")
+    . H.replaceAll "&" (const "&amp;")
 
-replaceTitleAmp :: H.Metadata -> String
-replaceTitleAmp =
-  replaceAmp . safeTitle
+escapedTitle :: H.Metadata -> String
+escapedTitle =
+  escapeXml . safeTitle
 
 safeTitle :: H.Metadata -> String
 safeTitle =
@@ -73,4 +79,4 @@ safeTitle =
 
 updatedTitle :: H.Item a -> H.Compiler String
 updatedTitle =
-  fmap replaceTitleAmp . H.getMetadata . H.itemIdentifier
+  fmap escapedTitle . H.getMetadata . H.itemIdentifier

--- a/ssg/src/Text/HTML/TagSoup/Compressor.hs
+++ b/ssg/src/Text/HTML/TagSoup/Compressor.hs
@@ -28,38 +28,45 @@ __Examples__ (with @parse = 'TS.parseTags'@ and @render = 'TS.renderTags'@):
 compress :: [TS.Tag String] -> [TS.Tag String]
 compress = go Set.empty
   where
+    -- Fold over the tag stream while carrying a `Set` of the element names we
+    -- are currently "inside", so we know when a text node's whitespace is
+    -- significant (see `insideSignificant`) and must be preserved.
     go :: Set.Set String -> [TS.Tag String] -> [TS.Tag String]
     go stack =
       \case
         [] -> []
 
-        -- Drop HTML comments: skip the tag and continue.
+        -- Remove an HTML comment by *not* prepending the tag and, instead,
+        -- continuing on with the rest of the tags.
         (TS.TagComment _ : rest) ->
           go stack rest
 
-        -- Track which elements we are currently inside by pushing the
-        -- (lower-cased) name on open...
+        -- On an open tag, like `<div>`, prepend it and continue, pushing its
+        -- (lower-cased) name onto the stack of elements we are inside.
         (tag@(TS.TagOpen name _) : rest) ->
           tag : go (Set.insert (lower name) stack) rest
 
-        -- ...and popping it back off on close.
+        -- On a closing tag, like `</div>`, prepend it and continue, popping its
+        -- name back off the stack.
         (tag@(TS.TagClose name) : rest) ->
           tag : go (Set.delete (lower name) stack) rest
 
-        -- Leave text inside whitespace-sensitive elements alone; collapse
-        -- insignificant whitespace everywhere else.
+        -- On a text node: if it sits inside a whitespace-sensitive element,
+        -- prepend it unchanged; otherwise, clean up its whitespace first.
         (tag@(TS.TagText _) : rest)
           | insideSignificant stack -> tag : go stack rest
           | otherwise               -> fmap cleanWhitespace tag : go stack rest
 
-        -- Anything else passes through unchanged.
+        -- Anything else is unexpected, so prepend it without change.
         (tag : rest) ->
           tag : go stack rest
 
     lower :: String -> String
     lower = map toLower
 
-    -- Elements whose whitespace-significant content must be preserved verbatim.
+    -- Elements whose whitespace is significant and must be preserved verbatim.
+    -- `script`/`style` matter too: collapsing newlines inside inline JS can
+    -- swallow a `//` line comment or change automatic-semicolon-insertion.
     insideSignificant :: Set.Set String -> Bool
     insideSignificant stack =
       any (`Set.member` stack) [ "pre", "script", "style", "textarea" ]
@@ -68,8 +75,14 @@ compress = go Set.empty
     cleanWhitespace " " = " "
     cleanWhitespace str = cleanSurroundingWhitespace str (cleanHtmlWhitespace str)
       where
-        -- Space, form feed, newline, carriage return, vertical tab. (Kept
-        -- narrow on purpose so non-breaking spaces etc. survive.)
+        -- The whitespace we treat as insignificant:
+        --   ' '  (space)
+        --   '\f' (form feed)
+        --   '\n' (newline / line feed)
+        --   '\r' (carriage return)
+        --   '\v' (vertical tab)
+        -- Deliberately narrower than `Data.Char.isSpace` so non-breaking spaces
+        -- and similar are left alone.
         isSpaceOrNewLineIsh :: Char -> Bool
         isSpaceOrNewLineIsh = (`elem` (" \f\n\r\v" :: String))
 
@@ -77,15 +90,18 @@ compress = go Set.empty
         cleanHtmlWhitespace :: String -> String
         cleanHtmlWhitespace = unwords . words'
           where
+            -- Like `words`, but splitting on `isSpaceOrNewLineIsh` rather than
+            -- `isSpace`, so we don't drop the whitespace we mean to keep.
+            -- https://hackage.haskell.org/package/base/docs/src/Data.OldList.html#words
             words' :: String -> [String]
             words' s = case dropWhile isSpaceOrNewLineIsh s of
               "" -> []
               s' -> w : words' s''
                 where (w, s'') = break isSpaceOrNewLineIsh s'
 
-        -- Re-add a single leading/trailing space when the original text had
-        -- surrounding whitespace, so adjacent inline elements do not run
-        -- together (e.g. @<a>x</a> <b>y</b>@).
+        -- After trimming, re-add a single leading/trailing space when the
+        -- original text had surrounding whitespace, so adjacent inline elements
+        -- do not run together (e.g. @<a>x</a> <b>y</b>@).
         cleanSurroundingWhitespace :: String -> String -> String
         cleanSurroundingWhitespace _ "" = ""
         cleanSurroundingWhitespace original trimmed =

--- a/ssg/src/Text/HTML/TagSoup/Compressor.hs
+++ b/ssg/src/Text/HTML/TagSoup/Compressor.hs
@@ -3,18 +3,26 @@
 module Text.HTML.TagSoup.Compressor (compress) where
 
 --------------------------------------------------------------------------------
+import           Data.Char (toLower)
 import qualified Data.Set as Set
 import qualified Text.HTML.TagSoup as TS
 
 --------------------------------------------------------------------------------
-{- | Compresses TagSoup HTML strings by removing excess, non-significant
-     whitespace and HTML comments (optional).
-__Examples:__
+{- | Compress a stream of TagSoup tags by dropping HTML comments and collapsing
+     runs of insignificant whitespace. The contents of whitespace-sensitive
+     elements (@pre@, @textarea@, @script@, @style@) are left untouched.
+
+__Examples__ (with @parse = 'TS.parseTags'@ and @render = 'TS.renderTags'@):
+
 @
-compress TODO
--- "<RESULT>"
-compress TODO
--- "<RESULT>"
+> render . compress . parse $ "<p>  hello   world  </p>"
+"<p> hello world </p>"
+
+> render . compress . parse $ "<pre>  keep\\n  me  </pre>"
+"<pre>  keep\\n  me  </pre>"
+
+> render . compress . parse $ "<p>a</p><!-- gone --><p>b</p>"
+"<p>a</p><p>b</p>"
 @
 -}
 compress :: [TS.Tag String] -> [TS.Tag String]
@@ -22,91 +30,71 @@ compress = go Set.empty
   where
     go :: Set.Set String -> [TS.Tag String] -> [TS.Tag String]
     go stack =
-      \case [] -> []
-            -- Removes comments by not prepending the tag
-            -- and, instead, continuing on with the other tags
-            ((TS.TagComment _str):rest) ->
-              go stack rest
+      \case
+        [] -> []
 
-            -- When we find an open tag, like `<div>`, prepend it
-            -- and continue through the rest of the tags while
-            -- keeping a separate stack of what elements a given
-            -- tag is currently "inside"
-            (tag@(TS.TagOpen name _attrs):rest) ->
-              tag : go (Set.insert name stack) rest
+        -- Drop HTML comments: skip the tag and continue.
+        (TS.TagComment _ : rest) ->
+          go stack rest
 
-            -- When we find a closing tag, like `</div>`, prepend it
-            -- it and continue through the rest of the tags, making
-            -- sure to remove it from our stack of currently opened
-            -- elements
-            (tag@(TS.TagClose name):rest) ->
-              tag : go (Set.delete name stack) rest
+        -- Track which elements we are currently inside by pushing the
+        -- (lower-cased) name on open...
+        (tag@(TS.TagOpen name _) : rest) ->
+          tag : go (Set.insert (lower name) stack) rest
 
-            -- When a text/string tag is encountered, if it has
-            -- significant whitespace that should be preserved,
-            -- then prepend it without change; otherwise, clean up
-            -- the whitespace, and prepend it
-            (tag@(TS.TagText _str):rest)
-              | hasSignificantWhitespace stack -> tag : go stack rest
-              | otherwise -> fmap cleanWhitespace tag : go stack rest
+        -- ...and popping it back off on close.
+        (tag@(TS.TagClose name) : rest) ->
+          tag : go (Set.delete (lower name) stack) rest
 
-            -- If none of the above match, then this is unexpected,
-            -- so we should prepend the tag without change
-            (tag:rest) ->
-              tag : go stack rest
+        -- Leave text inside whitespace-sensitive elements alone; collapse
+        -- insignificant whitespace everywhere else.
+        (tag@(TS.TagText _) : rest)
+          | insideSignificant stack -> tag : go stack rest
+          | otherwise               -> fmap cleanWhitespace tag : go stack rest
 
-    -- Whitespace-sensitive content that shouldn't be compressed
-    hasSignificantWhitespace :: Set.Set String -> Bool
-    hasSignificantWhitespace stack =
-      any (`Set.member` stack) content
-      where
-        content = [ "pre", "textarea" ]
-        --content = [ "pre", "script", "textarea" ] -- @TODO: make `script` optional
+        -- Anything else passes through unchanged.
+        (tag : rest) ->
+          tag : go stack rest
+
+    lower :: String -> String
+    lower = map toLower
+
+    -- Elements whose whitespace-significant content must be preserved verbatim.
+    insideSignificant :: Set.Set String -> Bool
+    insideSignificant stack =
+      any (`Set.member` stack) [ "pre", "script", "style", "textarea" ]
 
     cleanWhitespace :: String -> String
     cleanWhitespace " " = " "
     cleanWhitespace str = cleanSurroundingWhitespace str (cleanHtmlWhitespace str)
       where
-        -- Tests for the following:
-        --   ' '  (space)
-        --   '\f' (form feed)
-        --   '\n' (newline [line feed])
-        --   '\r' (carriage return)
-        --   '\v' (vertical tab)
+        -- Space, form feed, newline, carriage return, vertical tab. (Kept
+        -- narrow on purpose so non-breaking spaces etc. survive.)
         isSpaceOrNewLineIsh :: Char -> Bool
         isSpaceOrNewLineIsh = (`elem` (" \f\n\r\v" :: String))
 
-        -- Strips out newlines, spaces, etc
+        -- Collapse internal runs of whitespace down to single spaces.
         cleanHtmlWhitespace :: String -> String
         cleanHtmlWhitespace = unwords . words'
           where
-            -- Alternate `words` function that uses a different
-            -- predicate than `isSpace` in order to avoid dropping
-            -- certain types of spaces.
-            -- https://hackage.haskell.org/package/base-4.17.0.0/docs/src/Data.OldList.html#words
             words' :: String -> [String]
             words' s = case dropWhile isSpaceOrNewLineIsh s of
               "" -> []
               s' -> w : words' s''
-                    where (w, s'') =
-                           break isSpaceOrNewLineIsh s'
+                where (w, s'') = break isSpaceOrNewLineIsh s'
 
-        -- Clean the whitespace while preserving
-        -- single leading and trailing whitespace
-        -- characters when it makes sense
+        -- Re-add a single leading/trailing space when the original text had
+        -- surrounding whitespace, so adjacent inline elements do not run
+        -- together (e.g. @<a>x</a> <b>y</b>@).
         cleanSurroundingWhitespace :: String -> String -> String
-        cleanSurroundingWhitespace _originalStr "" = ""
-        cleanSurroundingWhitespace originalStr trimmedStr =
-          leadingStr ++ trimmedStr ++ trailingStr
+        cleanSurroundingWhitespace _ "" = ""
+        cleanSurroundingWhitespace original trimmed =
+          spaceWhen startsWithSpace ++ trimmed ++ spaceWhen endsWithSpace
           where
-            leadingStr  = keepSpaceWhen head originalStr
-            trailingStr = keepSpaceWhen last originalStr
-
-        -- Determine when to keep a space based on a
-        -- string and a function that returns a character
-        -- within that string
-        keepSpaceWhen :: ([Char] -> Char) -> String -> String
-        keepSpaceWhen _fn ""  = ""
-        keepSpaceWhen fn originalStr
-          | (isSpaceOrNewLineIsh . fn) originalStr = " "
-          | otherwise = ""
+            spaceWhen p = if p then " " else ""
+            startsWithSpace = case original of
+              (c : _) -> isSpaceOrNewLineIsh c
+              _       -> False
+            endsWithSpace = case reverse original of
+              (c : _) -> isSpaceOrNewLineIsh c
+              _       -> False


### PR DESCRIPTION
## Summary

Syncs the HTML compressor with improvements made upstream in [hakyll-nix-template](https://github.com/rpearce/hakyll-nix-template) and fixes an invalid-feed-XML bug. Verified with `nix build`.

## Changes

**`Text.HTML.TagSoup.Compressor`** — improved and kept **byte-identical** to the template's copy:
- also protect `<script>`/`<style>` content, not just `<pre>`/`<textarea>` (collapsing whitespace inside inline JS can swallow a `//` line comment or break ASI)
- lower-case tag names before the significant-set check, so `<PRE>`/`<TEXTAREA>` are protected too
- real Haddock examples instead of `TODO` placeholders
- (behaviourally a no-op for this site's current output — all latent-bug fixes)

**`Hakyll.Site.Feed`** — escape `<`, `>`, and `"` in feed titles, not just `&`. Previously a post title containing any of those produced **invalid RSS/Atom XML** (this is the template's 4-char `escapeXml`, ported up).

## Verified

`nix build` regenerates the full site (52 pages) and RSS/Atom feeds render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
