### PR TITLE
Update the hakyll-nix-template tutorial for the 2026 template

### DIFF
--- a/src/posts/2023-02-12-hakyll-nix-template-tutorial.md
+++ b/src/posts/2023-02-12-hakyll-nix-template-tutorial.md
@@ -4,6 +4,7 @@ authorTwitter: "@RobertWPearce"
 desc: "A full walkthrough for getting set up to create static sites using nix and hakyll"
 keywords: "hakyll, nix, hakyll-nix-template, haskell, static site generators, functional programming, programming"
 title: "The hakyll-nix-template Tutorial"
+updated: "2026-07-31T12:00:00Z"
 ---
 
 If you're looking to use [hakyll](https://jaspervdj.be/hakyll) with
@@ -14,6 +15,15 @@ We will be working with the
 [hakyll-nix-template](https://github.com/rpearce/hakyll-nix-template/), so go
 ahead and pull that up in a new browser tab. Its README also contains info on
 all the features that are provided.
+
+_**Update, July 2026:** I've given the template a solid overhaul since I first
+wrote this, so I've gone back through the article to match. The short version:
+haskell.nix is gone (it's plain nixpkgs now, so there's no extra cache or trust
+setup to fuss with), deploys use GitHub's official Pages action instead of a
+`gh-pages` branch, the haskell code is split into small modules instead of one
+big `Main.hs`, your editor gets `haskell-language-server` for free, and your
+static assets bust their own browser caches. If you've followed along with this
+before, it's worth a re-skim._
 
 ## Overview
 
@@ -51,9 +61,16 @@ to copy the conf file, and just remove `https://rpearce.cachix.org` from
 `substituters` and `rpearce.cachix.org-1:...=` from the `trusted-public-keys`
 (or replace with your own cache from cachix!).
 
-While you're at it, we aren't using [devenv.sh](https://devenv.sh) nor
-[nix-direnv](https://github.com/nix-community/nix-direnv) in this example, but
-you should check them out later, too.
+Cachix is optional these days — everything this template needs comes prebuilt
+from the [official nix cache](https://cache.nixos.org) — but the GitHub workflow
+can push your own builds to your own cache, so I still think it's worth setting
+up.
+
+While you're at it, we aren't using [devenv.sh](https://devenv.sh) in this
+example, but you should check it out later. As for
+[nix-direnv](https://github.com/nix-community/nix-direnv), the template now
+ships an `.envrc`, so if you're a direnv person, you're already sorted; more on
+that in a bit.
 
 ## Copying the template
 
@@ -110,10 +127,12 @@ Alright! We're ready to build and personalize our project.
 
 ## Building the project
 
-Run `nix build`, answer any substituters trust prompts, and then go do something
-else for a while. The first run takes a while, and how long it takes depends on
-connection speed, processing speed, and — most importantly — what caches you
-have set up in `nix.conf` (and/or `flake.nix`).
+Run `nix build`, and then go do something else for a few minutes. The first run
+pulls down GHC, hakyll, pandoc, and friends, but they all come prebuilt from the
+[official nix cache](https://cache.nixos.org), so how long it takes mostly comes
+down to your connection speed; the only thing that gets compiled on your machine
+is the site generator itself. There are no substituter trust prompts to answer
+anymore, either — that all went away with haskell.nix.
 
 Once that is all done, you'll have a brand new `result/` directory available
 that is a symlink to `/nix/store/<HASH>-website/`. For this blog, it looks like
@@ -122,8 +141,6 @@ this:
 ```text
 result/
 └── dist/
-  ├── CNAME
-  ├── _config.yml
   ├── announcing-react-medium-image-zoom-v4.html
   ├── asynchronously-loading-scripts.html
   ├── atom.xml
@@ -172,12 +189,23 @@ while the first time):
 
 When you have `[hakyll-nix]λ ` as your prompt, you know that you're in a nix
 shell. This comes preloaded with _most_ of your existing CLI tools, plus
-`cabal`, `ghc`, `haskell-language-server`, and `hlint`. If you want it to be
-exactly your environment plus the nix develop shell, check out
-[nix-direnv](https://github.com/nix-community/nix-direnv).
+`cabal`, `ghc`, `haskell-language-server`, `hlint`, and `ormolu`. If you want it
+to be exactly your environment plus the nix develop shell, check out
+[nix-direnv](https://github.com/nix-community/nix-direnv); the template ships an
+`.envrc`, so all you have to do is run `direnv allow` once.
 
 At this point, if you're using Vim, for example, you can run `vim .` and open
 the project up _with access to the aforementioned tools_.
+
+If you're a VS Code person, there's a `.vscode/` folder in the template that
+recommends the Haskell and [Nix Env
+Selector](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector)
+extensions and points them at `shell.nix`, which is a little bridge to the same
+dev shell you just used. The upshot is that `haskell-language-server` runs from
+_this_ nix environment instead of downloading a copy of its own. As a bonus, HLS
+comes with hlint built in, so you get lint warnings and "apply hint" fixes
+without installing anything else. The template's README covers all of this under
+"Editor integration (HLS)".
 
 Now, it's time to customize the project for you.
 
@@ -186,70 +214,90 @@ Now, it's time to customize the project for you.
 First, go back to your window where you can `nix run . watch` and cancel that;
 e.g., press `ctrl + c`.
 
-Next, using your editor, open `ssg/src/Main.hs`, and read over the
+All of the haskell code used to live in one big `ssg/src/Main.hs` file, but I've
+since broken it up into modules that each do one thing:
+
+```text
+ssg/src/
+├── Main.hs                          -- wires all the rules together
+├── Hakyll/Site/
+│   ├── Assets.hs                    -- static asset cache-busting
+│   ├── Configuration.hs             -- your site info & hakyll config
+│   ├── CustomFields.hs              -- the optional `updated` date field
+│   ├── Feed.hs                      -- RSS & Atom feeds
+│   ├── Post.hs                      -- post context & title-slug filenames
+│   ├── Rules.hs                     -- the build rules & pandoc setup
+│   └── Sitemap.hs                   -- sitemap.xml
+└── Text/HTML/TagSoup/Compressor.hs  -- squishes the output HTML
+```
+
+Everything you need to personalize is in one place, though. Using your editor,
+open `ssg/src/Hakyll/Site/Configuration.hs`, and read over the
 `PERSONALIZATION` section near the top:
 
 ```haskell
-------------------
--- PERSONALIZATION
+data SiteConfiguration = SiteConfiguration
+  { siteName :: String
+  , siteRoot :: String
+  } deriving (Show)
 
-mySiteName :: String
-mySiteName = "My Site Name"
+siteConfiguration :: SiteConfiguration
+siteConfiguration =
+  SiteConfiguration
+    { siteName = "My Site Name"
+    , siteRoot = "https://my-site.com"
+    }
 
-mySiteRoot :: String
-mySiteRoot = "https://my-site.com"
-
-myFeedTitle :: String
-myFeedTitle = "My Site"
-
-myFeedDescription :: String
-myFeedDescription = "My Site Description"
-
-myFeedAuthorName :: String
-myFeedAuthorName = "My Name"
-
-myFeedAuthorEmail :: String
-myFeedAuthorEmail = "me@myemail.com"
-
-myFeedRoot :: String
-myFeedRoot = mySiteRoot
+-- https://github.com/jaspervdj/hakyll/blob/66ace430f90ec97cbb9cf278ec46aec3b457fc56/lib/Hakyll/Web/Feed.hs#L69-L81
+feedConfiguration :: H.FeedConfiguration
+feedConfiguration =
+  H.FeedConfiguration
+    { H.feedTitle = "My Feed Title"
+    , H.feedDescription = "My Site Description"
+    , H.feedAuthorName = "My Name"
+    , H.feedAuthorEmail = "me@myemail.com"
+    , H.feedRoot = "https://my-site.com"
+    }
 ```
 
-This area contains all the high level, site-based customization text and root
-URLs for you to update. Go ahead and do that.
+These two records contain all the high level, site-based customization text and
+root URLs for you to update. Go ahead and do that. Don't fret over whether your
+`siteRoot` has a trailing slash on it, by the way; that gets trimmed off for
+you, so your URLs won't come out with a double slash in them.
 
 Below this area, you'll find the `CONFIG` section:
 
 ```haskell
 -- Default configuration: https://github.com/jaspervdj/hakyll/blob/cd74877d41f41c4fba27768f84255e797748a31a/lib/Hakyll/Core/Configuration.hs#L101-L125
-config :: Configuration
-config =
-  defaultConfiguration
-    { destinationDirectory = "dist"
-    , ignoreFile = ignoreFile'
-    , previewHost = "127.0.0.1"
-    , previewPort = 8000
-    , providerDirectory = "src"
-    , storeDirectory = "ssg/_cache"
-    , tmpDirectory = "ssg/_tmp"
+hakyllConfiguration :: H.Configuration
+hakyllConfiguration =
+  H.defaultConfiguration
+    { H.destinationDirectory = "dist"
+    , H.ignoreFile = ignoreFile'
+    , H.previewHost = "127.0.0.1"
+    , H.previewPort = 8000
+    , H.providerDirectory = "src"
+    , H.storeDirectory = "ssg/_cache"
+    , H.tmpDirectory = "ssg/_tmp"
     }
   where
     ignoreFile' path
-      | "."    `isPrefixOf` fileName = False
-      | "#"    `isPrefixOf` fileName = True
-      | "~"    `isSuffixOf` fileName = True
-      | ".swp" `isSuffixOf` fileName = True
+      | ".DS_Store" == fileName           = True
+      | "."    `List.isPrefixOf` fileName = False
+      | "#"    `List.isPrefixOf` fileName = True
+      | "~"    `List.isSuffixOf` fileName = True
+      | ".swp" `List.isSuffixOf` fileName = True
       | otherwise = False
       where
-        fileName = takeFileName path
+        fileName = FP.takeFileName path
 ```
 
 This section specifically deals with your hakyll config. If you want to change
 the development server port, host, content, source directory, what files are or
 aren't ignored, and some caching things, then you can do so here.
 
-The rest of the file is all related to hakyll and the build, so if you know
-hakyll already, this should feel familiar, and feel free to customize it
+The rest of the modules are all related to hakyll and the build, so if you know
+hakyll already, this should feel familiar, and feel free to customize things
 however you like.
 
 Do note that any changes you make inside of `ssg/` means you'll need to turn
@@ -307,10 +355,7 @@ If you open `src/templates/post.html`, you'll see something like this:
         <a href=".$url$">$title$</a>
       </h1>
       <div>
-        <small>$date$</small>
-        $if(updated)$
-        <small>(updated: $updated$)</small>
-        $endif$
+        $date$ $if(updated)$(updated: $updated$)$endif$
       </div>
     </header>
     <section>
@@ -327,15 +372,17 @@ See `$title$`? That comes from our post metadata, and `updated` looks like it's
 an optional field from our metadata, but where does `$date$` come from? Or
 `$body$`?
 
-In `ssg/src/Main.hs`, you'll see `postCtx`:
+In `ssg/src/Hakyll/Site/Post.hs`, you'll see `postCtx`:
 
 ```haskell
-postCtx :: Context String
+postCtx :: H.Context String
 postCtx =
-  constField "root" mySiteRoot
-    <> constField "siteName" mySiteName
-    <> dateField "date" "%Y-%m-%d"
-    <> defaultContext
+  H.constField "root" HSConfig.mySiteRoot
+    <> H.constField "feedTitle" HSConfig.myFeedTitle
+    <> H.constField "siteName" HSConfig.mySiteName
+    <> H.dateField "date" "%Y-%m-%d"
+    <> HSCustomFields.updatedField "updated" "%Y-%m-%d"
+    <> H.defaultContext
 ```
 
 This is a post context that gets built up and supplied to the template. Hakyll
@@ -343,6 +390,13 @@ has [a special `dateField` helper](https://github.com/jaspervdj/hakyll/blob/909e
 that parses a date from your post filename if it begins with a date. It also has
 [`defaultContext`](https://github.com/jaspervdj/hakyll/blob/909e1b3a89b5b3ba5f64840d23ada9b3ac393404/lib/Hakyll/Web/Template/Context.hs#L231-L249)
 which handles things like your post/web page's body content.
+
+That `updatedField` is one I wrote, and it lives in
+`ssg/src/Hakyll/Site/CustomFields.hs`. If a post has an `updated` value in its
+front-matter, it parses that (in a few different date formats) and hands your
+templates back a tidy `$updated$` date to print; if there isn't one, the
+`$if(updated)$` block above simply doesn't render. It's what's producing the
+"Revised" row in this very article's info table.
 
 What is significant about this example is that this is a place where you can
 pass in values at a global level; note that `constField` is including some of
@@ -366,41 +420,53 @@ format:
 ## Determining what static files are copied over
 
 You will inevitably want to copy static files from your source code into your
-outputted build, and this is easily with hakyll's `copyFileCompiler` in
-`ssg/src/Main.hs`, just inside the `main` function.
+outputted build, and this is easily done with hakyll's `copyFileCompiler`. These
+days, `ssg/src/Main.hs` is a thin list of rules, and the copying happens in the
+`COPY FILES` block:
 
 ```haskell
 main :: IO ()
-main = hakyllWith config $ do
-  forM_
-    [ "CNAME"
-    , "favicon.ico"
-    , "robots.txt"
-    , "_config.yml"
-    , "images/*"
-    , "js/*"
-    , "fonts/*"
-    ]
-    $ \f -> match f $ do
-      route idRoute
-      compile copyFileCompiler
+main = do
+  -- Fingerprint the static assets up front so rendered pages can cache-bust
+  -- their URLs with `?v=<hash>` (see Hakyll.Site.Assets).
+  manifest <-
+    HSAssets.buildManifest
+      (H.providerDirectory HSConfig.hakyllConfiguration)
+      [ ("css/code.css", HSRules.codeCssContent) ]
+
+  H.hakyllWith HSConfig.hakyllConfiguration $ do
+    -- COPY FILES
+    H.match "favicon.ico" HSRules.copy
+    H.match "robots.txt"  HSRules.copy
+    H.match "images/*"    HSRules.copy
+    H.match "js/*"        HSRules.copy
+    H.match "fonts/*"     HSRules.copy
+    -- ...
 ```
 
 Each file or folder glob here exists inside the `src/` directory. If you have
-something you want copied over to the build, this is the place to do it.
+something you want copied over to the build, this is the place to do it: add a
+line like `H.match "pdfs/*" HSRules.copy`, and you're done.
 
 If you find you need to ignore a certain file or extension, consult the
-`ignoreFile'` function in the `config` and add your problematic file, prefix, or
-extension to the guard. For example, my macOS likes to add `.DS_Store`
-everywhere, so I did this:
+`ignoreFile'` function in `Configuration.hs` and add your problematic file,
+prefix, or extension to the guard. For example, my macOS likes to add
+`.DS_Store` everywhere, so I did this — and it now ships in the template, so
+that's one less thing for you to do:
 
 ```haskell
 ignoreFile' path
-  | ".DS_Store" == fileName = True -- this line
-  | "."    `isPrefixOf` fileName = False
-  | "#"    `isPrefixOf` fileName = True
+  | ".DS_Store" == fileName           = True -- this line
+  | "."    `List.isPrefixOf` fileName = False
+  | "#"    `List.isPrefixOf` fileName = True
   | -- ...
 ```
+
+Two other things you don't have to think about: a `.nojekyll` file gets
+generated for you, so GitHub Pages serves your output exactly as hakyll wrote it
+(no Jekyll processing, no ignored underscore folders), and every reference to
+those static files gets cache-busted for you — which brings us neatly to a TODO
+I finally got around to, [further down](#todo-caching-and-hashing).
 
 ## Understanding the GitHub action workflow
 
@@ -414,18 +480,29 @@ This is the main job, and it does four things:
 
 1. Install nix
 1. Setup the build to run with cachix
-1. Run `nix-build`
-1. Temporarily upload the result of `nix-build` for use later (your website
-   output)
+1. Run `nix build`
+1. Upload the built site (`result/dist`) as a GitHub Pages artifact
 
 ### The `deploy` job
 
 When code is pushed to the `main` branch, the `deploy` job will:
 
 1. Run the `build-nix` job
-1. Download the temporarily uploaded website output
-1. If the prior step succeeds, it will checkout the `gh-pages` branch and
-   deploy your code to that branch
+1. Hand that uploaded artifact to GitHub's official
+   [`actions/deploy-pages`](https://github.com/actions/deploy-pages) action,
+   which publishes it for you
+
+There's no `gh-pages` branch involved anymore, which I'm quite happy about: your
+built site goes straight to GitHub Pages, and there's no commit history of
+generated files to lug around. The job proves who it is with a short-lived
+[OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+token that GitHub mints on the spot, so there's no deploy key or long-lived
+token for you to manage.
+
+You'll also notice each action is pinned to a full commit SHA with its version
+in a comment next to it, e.g. `actions/checkout@9c091bb... # v7`. Tags can be
+moved; commits can't, so this means nobody can swap out the code you're running
+from under you. Dependabot updates those pins for you.
 
 ### Adding your `CACHIX_AUTH_TOKEN`
 
@@ -442,20 +519,24 @@ are the steps to setting this up:
 
 ## Enabling GitHub Pages
 
-While you're in the `Settings` tab, go to the `Pages` page, enable GitHub Pages,
-set the `Source` to `Deploy from a branch`, set that branch to `gh-pages`, and
-make sure the directory for that branch is `/ (root)`.
+While you're in the `Settings` tab, go to the `Pages` page and, under `Build and
+deployment`, set the `Source` to `GitHub Actions`. That's the whole thing —
+there's no branch or directory to pick anymore, since the workflow hands your
+built site to GitHub directly.
 
-<img
-  alt="The GitHub Pages setup for this website"
-  decoding="async"
-  height="517"
-  loading="lazy"
-  src="./images/hnt-gh-pages.webp"
-  width="600"
-/>
+<!-- TODO(rpearce): reshoot ./images/hnt-gh-pages.webp showing
+     Source = "GitHub Actions" and re-add the screenshot here -->
+
+Don't skip this one! Until you flip that setting, your `deploy` job will fail,
+because your repository isn't expecting deploys from Actions yet.
 
 ## Deploying to your domain
+
+On that same `Pages` settings page, there's a `Custom domain` field: pop your
+domain in there. The template doesn't ship a `CNAME` file anymore, because
+GitHub holds onto that setting for you; if you'd rather keep your domain in
+version control, you can still add a `CNAME` file to `src/` and a copy rule for
+it in `Main.hs`.
 
 Follow the [GitHub Pages custom domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)
 for heaps of info on how to deploy your site to your web domain.
@@ -465,20 +546,37 @@ for heaps of info on how to deploy your site to your web domain.
 ### TODO: Caching and hashing
 
 When a CSS or JS file changes, we need a way to break browser caches to ensure
-they get the latest version. The way to do this is to generate a hash of that
-file's contents, generate a file with that content hash in the filename when
-building, and then make sure any output that references that CSS or JS file
-reflects this updated filename, as well.
+they get the latest version.
 
-I have no idea how to do this yet, but I'll figure it out!
+**Update, July 2026: I figured it out!** My original plan was to hash a file's
+contents, write out a new file with that hash in its name, and then rewrite
+every reference to it. What the template does now is a bit simpler: before the
+build starts, it hashes everything in your `css`, `js`, `images`, `fonts`, and
+`pdfs` folders (plus your `favicon.ico`), and then, as each page gets rendered,
+it tacks a `?v=<hash>` query string onto every `href`, `src`, and social image
+URL that points at one of those files.
+
+The result is the same — change a file, and only that file's URL changes, so
+browsers refetch that one thing and keep the rest — but your output directory
+stays free of mystery filenames, and there's nothing for you to wire up in your
+templates. Have a look at `ssg/src/Hakyll/Site/Assets.hs` if you're curious
+about how it works.
 
 ### TODO: Use pygments for syntax highlighting
 
 See [Tony Zorman's post on pygmentising hakyll](https://tony-zorman.com/posts/2023-01-21-pygmentising-hakyll.html)
 for details on some issues with the [skylighting
-library](https://hackage.haskell.org/package/skylighting). I'll likely follow
-this post in order to switch up the syntax highlighting to something better, or
-at least allow people to work with whatever they want.
+library](https://hackage.haskell.org/package/skylighting).
+
+**Update, July 2026:** I did this for this website, but not for the template.
+Following Tony's post, this site pipes its code blocks through
+[chroma](https://github.com/alecthomas/chroma) — same idea as pygments, but it's
+a single Go binary — and that's what's highlighting the snippets you're reading
+right now. The template still uses skylighting, and I'm leaving it that way on
+purpose: it needs no external program, so anyone who clicks "Use this template"
+gets a site that builds straight away. The template generates its highlighting
+stylesheet into `css/code.css` at build time, so it's cache-busted along with
+everything else.
 
 ## Other hakyll posts
 


### PR DESCRIPTION
The template has changed a lot since this was written: haskell.nix is gone, deploys go through GitHub's official Pages action, the ssg code is split into modules, editor/HLS setup ships with the template, and static assets are cache-busted.

Revise the article in place (rather than striking through and appending) and add a dated update note up top, plus an `updated` front-matter value so the Info table shows when it was revised. Both TODO sections are now marked as done, with their headings left alone so existing anchors keep working.

The GitHub Pages screenshot showed the old "Deploy from a branch" setting, so it is removed for now with a note in the source to reshoot it.